### PR TITLE
[SSH] Handle SSH version 1.99

### DIFF
--- a/scripts/base/protocols/ssh/main.zeek
+++ b/scripts/base/protocols/ssh/main.zeek
@@ -169,9 +169,12 @@ event ssh_client_version(c: connection, version: string)
 	set_session(c);
 	c$ssh$client = version;
 
-	if ( ( |version| > 3 ) && ( version[4] == "1" ) )
-		c$ssh$version = 1;
-	if ( ( |version| > 3 ) && ( version[4] == "2" ) )
+	if ( ( |version| > 4 ) && ( version[4] == "1" ) )
+		if ( ( |version| > 8 ) && ( version[6] == "9" ) && ( version[7] == "9" ) )
+			c$ssh$version = 2;
+		else
+			c$ssh$version = 1;
+	if ( ( |version| > 4 ) && ( version[4] == "2" ) )
 		c$ssh$version = 2;
 	}
 

--- a/src/analyzer/protocol/ssh/consts.pac
+++ b/src/analyzer/protocol/ssh/consts.pac
@@ -2,6 +2,7 @@ enum version {
 	SSH1 = 1,
 	SSH2 = 2,
 	UNK  = 3,
+	SSH199 = 4,
 };
 
 enum state {


### PR DESCRIPTION
SSH can set in its identification a version 1.99 (SSH-1.99-xxx).
That means the client/server is compatible with SSHv1 and SSHv2.
So the version choice depends of the both side.

1.99 : 1.99 => 2.0
1.99 : 1.x  => 1.x
1.99 : 2.0  => 2.O

(see "Compatibility With Old SSH Versions" in RFC 4253)